### PR TITLE
Fix {psd|rmse}_based_scores_from_ds

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -150,12 +150,12 @@ def load_altimetry_data(path, obs_from_tgt=False):
         .assign(
             input=lambda ds: ds.nadir_obs,
             tgt=lambda ds: remove_nan(ds.ssh),
-        )    
+        )
     )
 
     if obs_from_tgt:
         ds = ds.assign(input=ds.tgt.where(np.isfinite(ds.input), np.nan))
-    
+
     return (
         ds[[*src.data.TrainingItem._fields]]
         .transpose("time", "lat", "lon")
@@ -186,13 +186,13 @@ def load_full_natl_data(
 
 def rmse_based_scores_from_ds(ds, ref_variable='tgt', study_variable='out'):
     try:
-        return rmse_based_scores(ds[ref_variable], ds[study_variable])[2:]
+        return rmse_based_scores(ds[study_variable], ds[ref_variable])[2:]
     except:
         return [np.nan, np.nan]
 
 def psd_based_scores_from_ds(ds, ref_variable='tgt', study_variable='out'):
     try:
-        return psd_based_scores(ds[ref_variable], ds[study_variable])[1:]
+        return psd_based_scores(ds[study_variable], ds[ref_variable])[1:]
     except:
         return [np.nan, np.nan]
 


### PR DESCRIPTION
The function {psd|rmse}_based_scores takes as input: 1) the reconstructed signal, and then 2) the reference signal.

The function {psd|rmse}_based_scores_from_ds gives the arguments in the wrong order; this commit fixes it.