### PR TITLE
Fix ImportError related to MKL

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -18,6 +18,7 @@ dependencies:
   - scipy
   - matplotlib
   - holoviews
+  - mkl=2024.0
   - pip:
     - GitPython
     - einops


### PR DESCRIPTION
The dependency MKL 2024.1 seems to be responsible for the ImportError:

```libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent```

It is dynamically installed with the latest version of PyTorch.
This commit fixes the environment.yaml file to prevent this error to occur

See https://github.com/pytorch/pytorch/issues/123097